### PR TITLE
Remove explicit dependency on OmniAuth gem

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -1,4 +1,3 @@
-require 'omniauth'
 require 'omniauth-oauth2'
 require 'json/jwt'
 require 'uri'

--- a/omniauth-keycloak.gemspec
+++ b/omniauth-keycloak.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday'
   spec.add_dependency 'json-jwt', '> 1.13.0'
-  spec.add_dependency 'omniauth', '>= 2.0'
   spec.add_dependency 'omniauth-oauth2', '>= 1.7', '< 1.9'
 end


### PR DESCRIPTION
OmniAuth is a dependency of `omniauth-oauth2`, and is `require`d by `omniauth-oauth2`.

This commit removes the explicit dependency on omniauth, like other gems are doing