### PR TITLE
Prefer require_relative to require

### DIFF
--- a/lib/omniauth-keycloak.rb
+++ b/lib/omniauth-keycloak.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-require 'keycloak/version'
-require 'omniauth/strategies/keycloak-openid'
+require_relative 'keycloak/version'
+require_relative 'omniauth/strategies/keycloak-openid'


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- rubocop/rubocop#8748
- ruby/ruby@594633f