### PR TITLE
Remove instructions for Keycloak < 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,6 @@ Or install it yourself as:
 
     $ gem install omniauth-keycloak
 
-## Use with Keycloak >= 17 (Quarkus distribution)
-In version 17 of Keycloak, `/auth` was removed from the default context path. (See Issue [#29](https://github.com/ccrockett/omniauth-keycloak/issues/29))
-In order to reduce breaking existing user's setup, this gem assumes `/auth` as the default context.
-__So if you want to use Keycloak 17 or greater then you must do one of the following:__
-
-1. Pass in `--http-relative-path '/auth'` option with the keycloak start command
-2. Pass in a empty string for you base_url client_option:
-  `client_options: {base_url: '', site: 'https://example.keycloak-url.com', realm: 'example-realm'}`
-
 ## Usage
 
 `OmniAuth::Strategies::Keycloak` is simply a Rack middleware. Read the OmniAuth docs for detailed instructions: https://github.com/intridea/omniauth.
@@ -111,13 +102,13 @@ end
 
 ## Configuration
   * __Base Url other than /auth__
-  This gem tries to get the keycloak configuration from `"#{site}/auth/realms/#{realm}/.well-known/openid-configuration"`. If your keycloak server has been setup to use a different "root" url other than `/auth` then you need to pass in the `base_url` option when setting up the gem:
+  This gem tries to get the keycloak configuration from `"#{site}/realms/#{realm}/.well-known/openid-configuration"`. If your keycloak server has been setup to use a different "root" url then you need to pass in the `base_url` option when setting up the gem:
     ```ruby
     Rails.application.config.middleware.use OmniAuth::Builder do
       provider :keycloak,
         'Client-ID',
         'client-secret',
-        client_options: { site: 'https://keycloak.example.com', realm: 'example-realm', base_url: '/authorize' },
+        client_options: { site: 'https://keycloak.example.com', realm: 'example-realm' },
         name: 'keycloak'
     end
     ```

--- a/lib/omniauth/strategies/keycloak.rb
+++ b/lib/omniauth/strategies/keycloak.rb
@@ -63,7 +63,7 @@ module OmniAuth
       end
 
       def auth_url_base
-        return '/auth' unless options.client_options[:base_url]
+        return '' unless options.client_options[:base_url]
 
         base_url = options.client_options[:base_url]
         return base_url if base_url == '' || base_url[0] == '/'

--- a/spec/omniauth/strategies/keycloak_spec.rb
+++ b/spec/omniauth/strategies/keycloak_spec.rb
@@ -5,14 +5,14 @@ require 'spec_helper'
 RSpec.describe OmniAuth::Strategies::Keycloak do
   let(:body) do
     {
-      issuer: 'http://localhost:8080/auth/realms/example-realm',
-      authorization_endpoint: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/auth',
-      token_endpoint: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/token',
-      token_introspection_endpoint: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/token/introspect',
-      userinfo_endpoint: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/userinfo',
-      end_session_endpoint: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/logout',
-      jwks_uri: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/certs',
-      check_session_iframe: 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/login-status-iframe.html',
+      issuer: 'http://localhost:8080/realms/example-realm',
+      authorization_endpoint: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/auth',
+      token_endpoint: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/token',
+      token_introspection_endpoint: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/token/introspect',
+      userinfo_endpoint: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/userinfo',
+      end_session_endpoint: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/logout',
+      jwks_uri: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/certs',
+      check_session_iframe: 'http://localhost:8080/realms/example-realm/protocol/openid-connect/login-status-iframe.html',
       grant_types_supported: %w[authorization_code implicit refresh_token password client_credentials],
       response_types_supported: ['code', 'none', 'id_token', 'token', 'id_token token', 'code id_token',
                                  'code token', 'code id_token token'],
@@ -21,7 +21,7 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
       userinfo_signing_alg_values_supported: ['RS256'],
       request_object_signing_alg_values_supported: %w[none RS256],
       response_modes_supported: %w[query fragment form_post],
-      registration_endpoint: 'http://localhost:8080/auth/realms/example-realm/clients-registrations/openid-connect',
+      registration_endpoint: 'http://localhost:8080/realms/example-realm/clients-registrations/openid-connect',
       token_endpoint_auth_methods_supported: %w[private_key_jwt client_secret_basic client_secret_post],
       token_endpoint_auth_signing_alg_values_supported: ['RS256'],
       claims_supported: %w[sub iss auth_time name given_name family_name preferred_username
@@ -36,9 +36,9 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
 
   context 'with client options' do
     subject(:strategy) do
-      stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/.well-known/openid-configuration')
+      stub_request(:get, 'http://localhost:8080/realms/example-realm/.well-known/openid-configuration')
         .to_return(status: 200, body: JSON.generate(body), headers: {})
-      stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/certs')
+      stub_request(:get, 'http://localhost:8080/realms/example-realm/protocol/openid-connect/certs')
         .to_return(status: 404, body: '', headers: {})
       described_class.new('keycloak', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
                           client_options: { site: 'http://localhost:8080/', realm: 'example-realm' })
@@ -46,12 +46,12 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
 
     it 'has the correct keycloak token url' do
       strategy.setup_phase
-      expect(strategy.token_url).to eq('/auth/realms/example-realm/protocol/openid-connect/token')
+      expect(strategy.token_url).to eq('/realms/example-realm/protocol/openid-connect/token')
     end
 
     it 'has the correct keycloak authorization url' do
       strategy.setup_phase
-      expect(strategy.authorize_url).to eq('/auth/realms/example-realm/protocol/openid-connect/auth')
+      expect(strategy.authorize_url).to eq('/realms/example-realm/protocol/openid-connect/auth')
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
     subject(:strategy) do
       stub_request(:get, config_url)
       described_class.new('keycloak', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
-                          client_options: { site: 'http://localhost:8080/', realm: 'example-realm', base_url: '' })
+                          client_options: { site: 'http://localhost:8080/', realm: 'example-realm' })
     end
 
     let(:config_url) { 'http://localhost:8080/realms/example-realm/.well-known/openid-configuration' }
@@ -114,7 +114,7 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
       subject(:strategy) do
         stub_request(:get, 'http://localhost:8080/realms/example-realm/.well-known/openid-configuration')
           .to_return(status: 200, body: JSON.generate(body), headers: {})
-        stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/certs')
+        stub_request(:get, 'http://localhost:8080/realms/example-realm/protocol/openid-connect/certs')
           .to_return(status: 404, body: '', headers: {})
         described_class.new('keycloak', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
                             client_options: {
@@ -188,7 +188,7 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
     context 'when raise_on_failure option is true' do
       context 'when openid configuration endpoint returns error response' do
         subject(:strategy) do
-          stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/.well-known/openid-configuration')
+          stub_request(:get, 'http://localhost:8080/realms/example-realm/.well-known/openid-configuration')
             .to_return(status: 404, body: '', headers: {})
           described_class.new('keycloak', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
                               client_options: {
@@ -204,9 +204,9 @@ RSpec.describe OmniAuth::Strategies::Keycloak do
 
       context 'when certificates endpoint returns error response' do
         subject(:strategy) do
-          stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/.well-known/openid-configuration')
+          stub_request(:get, 'http://localhost:8080/realms/example-realm/.well-known/openid-configuration')
             .to_return(status: 200, body: JSON.generate(body), headers: {})
-          stub_request(:get, 'http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/certs')
+          stub_request(:get, 'http://localhost:8080/realms/example-realm/protocol/openid-connect/certs')
             .to_return(status: 404, body: '', headers: {})
           described_class.new('keycloak', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
                               client_options: {


### PR DESCRIPTION
Keycloak 17 is three years old, assume `/auth` is not the default anymore