### PR TITLE
Add decoded ID token to extra payload

### DIFF
--- a/lib/omniauth/strategies/keycloak.rb
+++ b/lib/omniauth/strategies/keycloak.rb
@@ -77,10 +77,16 @@ module OmniAuth
       end
 
       extra do
-        {
-          'raw_info' => raw_info,
-          'id_token' => access_token['id_token']
+        result = {
+          'raw_info' => raw_info
         }
+
+        if (id_token = access_token['id_token'])
+          result['id_token'] = id_token
+          result['id_info'] = decode_token(id_token)
+        end
+
+        result
       end
 
       protected


### PR DESCRIPTION
When the `openid` scope is requested, an `id_token` is returned by `get_token`.

This change adds the decoded `id_token` to the `extra` payload alongside the decoded `access_token`.

This approach aligns with common Omniauth strategies and ensures that `id_token` information is available for downstream consumers.

Ref: #61